### PR TITLE
Prevent multiple networks call when selecting import proposals states

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { EventsScreen } from './events/EventsScreen'
 import { LinkBehavior } from './components/CCLink'
 import { LinkProps } from '@mui/material/Link'
 import { QueryClient, QueryClientProvider } from 'react-query'
+import { ReactQueryDevtools } from 'react-query/devtools'
 
 const theme = createTheme({
     components: {
@@ -42,6 +43,7 @@ export const App = ({}) => {
                         </Switch>
                     </RequireLogin>
                 </ThemeProvider>
+                <ReactQueryDevtools />
             </QueryClientProvider>
         </Provider>
     )

--- a/src/conferencehall/components/ConferenceHallProposalsPicker.tsx
+++ b/src/conferencehall/components/ConferenceHallProposalsPicker.tsx
@@ -1,16 +1,17 @@
 import * as React from 'react'
 import { useEffect, useState } from 'react'
 import { ConferenceHallProposal, ConferenceHallProposalState } from '../../types'
-import { useConferenceHallProposals } from '../hooks/useConferenceHallProposals'
 import { FirestoreQueryLoaderAndErrorDisplay } from '../../components/FirestoreQueryLoaderAndErrorDisplay'
 import { Box, Typography } from '@mui/material'
 import { CheckboxButtonGroup, FormContainer, useForm } from 'react-hook-form-mui'
 import LoadingButton from '@mui/lab/LoadingButton'
 import * as yup from 'yup'
 import { yupResolver } from '@hookform/resolvers/yup/dist/yup'
+import { UseQueryResult } from 'react-query'
+import { DocumentData } from '@firebase/firestore'
 
 export type ConferenceHallProposalsPickerProps = {
-    eventId: string
+    proposals: UseQueryResult<DocumentData>
     onSubmit: (proposals: ConferenceHallProposal[]) => void
 }
 
@@ -20,14 +21,12 @@ const schema = yup
     })
     .required()
 
-export const ConferenceHallProposalsPicker = ({ eventId, onSubmit }: ConferenceHallProposalsPickerProps) => {
+export const ConferenceHallProposalsPicker = ({ proposals, onSubmit }: ConferenceHallProposalsPickerProps) => {
     const formContext = useForm({
         defaultValues: {
             states: [],
         },
     })
-    const proposals = useConferenceHallProposals(eventId)
-
     const [stats, setState] = useState({
         submitted: 0,
         accepted: 0,

--- a/src/conferencehall/components/ConferenceHallProposalsPickerConnected.tsx
+++ b/src/conferencehall/components/ConferenceHallProposalsPickerConnected.tsx
@@ -1,0 +1,18 @@
+import { ConferenceHallProposalsPicker } from './ConferenceHallProposalsPicker'
+import { useConferenceHallProposals } from '../hooks/useConferenceHallProposals'
+import React from 'react'
+import { ConferenceHallProposal } from '../../types'
+
+export type ConferenceHallProposalsPickerConnectedProps = {
+    eventId: string
+    onSubmit: (proposals: ConferenceHallProposal[]) => void
+}
+
+export const ConferenceHallProposalsPickerConnected = ({
+    eventId,
+    onSubmit,
+}: ConferenceHallProposalsPickerConnectedProps) => {
+    const proposals = useConferenceHallProposals(eventId)
+
+    return <ConferenceHallProposalsPicker onSubmit={onSubmit} proposals={proposals} />
+}

--- a/src/events/NewEventDialog.tsx
+++ b/src/events/NewEventDialog.tsx
@@ -14,10 +14,10 @@ import { RequireConferenceHallLogin } from '../conferencehall/RequireConferenceH
 import { ConferenceHallEventsPicker } from '../conferencehall/ConferenceHallEventsPicker'
 import { ConferenceHallEvent } from '../types'
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline'
-import { ConferenceHallProposalsPicker } from '../conferencehall/components/ConferenceHallProposalsPicker'
 import { addNewEvent } from './actions/addNewEvent'
 import { useSelector } from 'react-redux'
 import { selectUserIdConferenceCenter } from '../auth/authReducer'
+import { ConferenceHallProposalsPickerConnected } from '../conferencehall/components/ConferenceHallProposalsPickerConnected'
 
 export type NewEventDialogProps = {
     isOpen: boolean
@@ -72,7 +72,7 @@ export const NewEventDialog = ({ isOpen, onClose }: NewEventDialogProps) => {
                                                     3. Select the proposals to import (optional)
                                                 </Typography>
                                             </Box>
-                                            <ConferenceHallProposalsPicker
+                                            <ConferenceHallProposalsPickerConnected
                                                 eventId={selectedConferenceHallEvent.id}
                                                 onSubmit={async (proposals) => {
                                                     setNewResults(null)


### PR DESCRIPTION
linked to useConferenceHallProposals(eventId) being recalled to often (which should have been prevented by ReactQuery but /shrug? 